### PR TITLE
Add varchar support

### DIFF
--- a/dist/Utils/helpers.js
+++ b/dist/Utils/helpers.js
@@ -1,0 +1,19 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.quoteColumn = exports.quoteValue = exports.isEmpty = void 0;
+// Consider null, undefined and "" as empty, but not 0
+const isEmpty = (value) => !value && value !== 0;
+exports.isEmpty = isEmpty;
+const quoteValue = (item) => {
+    const shouldQuote = item.type === "text" ||
+        item.type === "blob" ||
+        item.type.match(/^varchar/i);
+    if ((0, exports.isEmpty)(item.value))
+        return "NULL";
+    return shouldQuote
+        ? `'${String(item.value).replace(/'/g, "''")}'`
+        : String(item.value);
+};
+exports.quoteValue = quoteValue;
+const quoteColumn = (columnOrTable) => "`" + columnOrTable + "`";
+exports.quoteColumn = quoteColumn;

--- a/dist/Utils/sqlGenerator.js
+++ b/dist/Utils/sqlGenerator.js
@@ -13,7 +13,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const databaseFunctions_1 = __importDefault(require("./databaseFunctions"));
-const shouldEscapeValue = (item) => item.type === "text" || item.type === "blob" || item.type.match(/^varchar/i);
+const shouldQuoteValue = (item) => item.type === "text" || item.type === "blob" || item.type.match(/^varchar/i);
 function generateInsertSQL(db, tableName, data) {
     return __awaiter(this, void 0, void 0, function* () {
         // Extract field names and escape values (optional for TEXT and BLOB)
@@ -25,7 +25,7 @@ function generateInsertSQL(db, tableName, data) {
                 if (!hasDefault.bool) {
                     // doesn't have default value
                     columns.push(item.field);
-                    if (shouldEscapeValue(item)) {
+                    if (shouldQuoteValue(item)) {
                         values.push(item.value !== ""
                             ? `'${String(item.value).replace(/'/g, "''")}'`
                             : "NULL" // Escape single quotes or use NULL
@@ -39,7 +39,7 @@ function generateInsertSQL(db, tableName, data) {
             else {
                 // doesn't have default value
                 columns.push(item.field);
-                if (shouldEscapeValue(item)) {
+                if (shouldQuoteValue(item)) {
                     values.push(item.value !== ""
                         ? `'${String(item.value).replace(/'/g, "''")}'`
                         : "NULL" // Escape single quotes or use NULL
@@ -65,7 +65,7 @@ function generateUpdateSQL(tableName, data, id, id_label) {
             item.value === undefined) {
             value = "NULL";
         }
-        else if (shouldEscapeValue(item)) {
+        else if (shouldQuoteValue(item)) {
             value = `'${String(item.value).replace(/'/g, "''")}'`; // Escape single quotes
         }
         else {

--- a/dist/Utils/sqlGenerator.js
+++ b/dist/Utils/sqlGenerator.js
@@ -13,6 +13,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const databaseFunctions_1 = __importDefault(require("./databaseFunctions"));
+const shouldEscapeValue = (item) => item.type === "text" || item.type === "blob" || item.type.match(/^varchar/i);
 function generateInsertSQL(db, tableName, data) {
     return __awaiter(this, void 0, void 0, function* () {
         // Extract field names and escape values (optional for TEXT and BLOB)
@@ -24,8 +25,7 @@ function generateInsertSQL(db, tableName, data) {
                 if (!hasDefault.bool) {
                     // doesn't have default value
                     columns.push(item.field);
-                    if (item.type.toUpperCase() === "TEXT" ||
-                        item.type.toUpperCase() === "BLOB") {
+                    if (shouldEscapeValue(item)) {
                         values.push(item.value !== ""
                             ? `'${String(item.value).replace(/'/g, "''")}'`
                             : "NULL" // Escape single quotes or use NULL
@@ -39,8 +39,7 @@ function generateInsertSQL(db, tableName, data) {
             else {
                 // doesn't have default value
                 columns.push(item.field);
-                if (item.type.toUpperCase() === "TEXT" ||
-                    item.type.toUpperCase() === "BLOB") {
+                if (shouldEscapeValue(item)) {
                     values.push(item.value !== ""
                         ? `'${String(item.value).replace(/'/g, "''")}'`
                         : "NULL" // Escape single quotes or use NULL
@@ -66,7 +65,7 @@ function generateUpdateSQL(tableName, data, id, id_label) {
             item.value === undefined) {
             value = "NULL";
         }
-        else if (item.type === "TEXT") {
+        else if (shouldEscapeValue(item)) {
             value = `'${String(item.value).replace(/'/g, "''")}'`; // Escape single quotes
         }
         else {

--- a/dist/Utils/sqlGenerator.js
+++ b/dist/Utils/sqlGenerator.js
@@ -13,19 +13,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const databaseFunctions_1 = __importDefault(require("./databaseFunctions"));
-// Consider null, undefined and "" as empty, but not 0
-const isEmpty = (value) => !value && value !== 0;
-const quoteValue = (item) => {
-    const shouldQuote = item.type === "text" ||
-        item.type === "blob" ||
-        item.type.match(/^varchar/i);
-    if (isEmpty(item.value))
-        return "NULL";
-    return shouldQuote
-        ? `'${String(item.value).replace(/'/g, "''")}'`
-        : String(item.value);
-};
-const quoteColumn = (columnOrTable) => "`" + columnOrTable + "`";
+const helpers_1 = require("./helpers");
 function generateInsertSQL(db, tableName, data) {
     return __awaiter(this, void 0, void 0, function* () {
         // Extract field names and escape values (optional for TEXT and BLOB)
@@ -33,10 +21,10 @@ function generateInsertSQL(db, tableName, data) {
         const values = [];
         yield Promise.all(data.map((item) => __awaiter(this, void 0, void 0, function* () {
             const hasDefault = yield databaseFunctions_1.default.checkColumnHasDefault(db, tableName, item.type.toUpperCase(), item.field);
-            if (isEmpty(item.value) && hasDefault.bool)
+            if ((0, helpers_1.isEmpty)(item.value) && hasDefault.bool)
                 return;
-            columns.push(quoteColumn(item.field));
-            values.push(quoteValue(item));
+            columns.push((0, helpers_1.quoteColumn)(item.field));
+            values.push((0, helpers_1.quoteValue)(item));
         })));
         // Form the SQL statement
         const sql = `INSERT INTO ${tableName} (${columns.join(", ")}) VALUES (${values.join(", ")});`;
@@ -46,10 +34,10 @@ function generateInsertSQL(db, tableName, data) {
 function generateUpdateSQL(tableName, data, id, id_label) {
     // Extract field names and values with proper handling
     const setClauses = data
-        .map((item) => `${quoteColumn(item.field)} = ${quoteValue(item)}`)
+        .map((item) => `${(0, helpers_1.quoteColumn)(item.field)} = ${(0, helpers_1.quoteValue)(item)}`)
         .join(", ");
     // Form the SQL statement
-    const sql = `UPDATE ${quoteColumn(tableName)} SET ${setClauses} WHERE ${id_label} = ${id};`;
+    const sql = `UPDATE ${(0, helpers_1.quoteColumn)(tableName)} SET ${setClauses} WHERE ${id_label} = ${id};`;
     return sql;
 }
 function generateCreateTableSQL(tableName, data) {
@@ -77,7 +65,7 @@ function generateCreateTableSQL(tableName, data) {
             default:
                 throw new Error(`Unknown type: ${item.type}`);
         }
-        let columnDefinition = `${quoteColumn(item.name)} ${columnType}`;
+        let columnDefinition = `${(0, helpers_1.quoteColumn)(item.name)} ${columnType}`;
         if (item.pk) {
             columnDefinition += ` ${item.pk}`; // Include primary key constraint
         }
@@ -88,13 +76,8 @@ function generateCreateTableSQL(tableName, data) {
     })
         .join(", ");
     // Form the SQL statement
-    let sql;
-    if (fk_array.length !== 0) {
-        sql = `CREATE TABLE IF NOT EXISTS ${quoteColumn(tableName)} (${columnDefinitions} ${"," + fk_array.join(",")});`;
-    }
-    else {
-        sql = `CREATE TABLE IF NOT EXISTS ${quoteColumn(tableName)} (${columnDefinitions});`;
-    }
+    const fkExtra = fk_array.length ? `${"," + fk_array.join(",")}` : "";
+    const sql = `CREATE TABLE IF NOT EXISTS ${(0, helpers_1.quoteColumn)(tableName)} (${columnDefinitions} ${fkExtra});`;
     return sql;
 }
 exports.default = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sqlite-gui-node",
-  "version": "1.3.2",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sqlite-gui-node",
-      "version": "1.3.2",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "body-parser": "^1.20.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite-gui-node",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "GUI for Node js SQLite databases",
   "main": "dist/index.js",
   "scripts": {

--- a/src/Utils/helpers.ts
+++ b/src/Utils/helpers.ts
@@ -1,0 +1,28 @@
+interface DataItem {
+  field: string;
+  name: string;
+  type: string;
+  value?: string | number | null; // Optional value based on type
+  pk?: string; // Optional primary key constraint
+  fk: string;
+  default?: string | number | null; // Optional default value
+}
+
+// Consider null, undefined and "" as empty, but not 0
+export const isEmpty = (value: string | number | null | undefined) =>
+  !value && value !== 0;
+
+export const quoteValue = (item: DataItem): string => {
+  const shouldQuote =
+    item.type === "text" ||
+    item.type === "blob" ||
+    item.type.match(/^varchar/i);
+
+  if (isEmpty(item.value)) return "NULL";
+
+  return shouldQuote
+    ? `'${String(item.value).replace(/'/g, "''")}'`
+    : String(item.value);
+};
+
+export const quoteColumn = (columnOrTable: string) => "`" + columnOrTable + "`";

--- a/src/Utils/helpers.ts
+++ b/src/Utils/helpers.ts
@@ -1,12 +1,4 @@
-interface DataItem {
-  field: string;
-  name: string;
-  type: string;
-  value?: string | number | null; // Optional value based on type
-  pk?: string; // Optional primary key constraint
-  fk: string;
-  default?: string | number | null; // Optional default value
-}
+import type { DataItem } from "../types";
 
 // Consider null, undefined and "" as empty, but not 0
 export const isEmpty = (value: string | number | null | undefined) =>

--- a/src/Utils/sqlGenerator.ts
+++ b/src/Utils/sqlGenerator.ts
@@ -1,15 +1,6 @@
+import type { DataItem } from "../types";
 import databaseFunctions from "./databaseFunctions";
 import { isEmpty, quoteColumn as q, quoteValue } from "./helpers";
-
-interface DataItem {
-  field: string;
-  name: string;
-  type: string;
-  value?: string | number | null; // Optional value based on type
-  pk?: string; // Optional primary key constraint
-  fk: string;
-  default?: string | number | null; // Optional default value
-}
 
 async function generateInsertSQL(
   db: any,

--- a/src/Utils/sqlGenerator.ts
+++ b/src/Utils/sqlGenerator.ts
@@ -10,6 +10,9 @@ interface DataItem {
   default?: string | number | null; // Optional default value
 }
 
+const shouldEscapeValue = (item: DataItem) =>
+  item.type === "text" || item.type === "blob" || item.type.match(/^varchar/i);
+
 async function generateInsertSQL(
   db: any,
   tableName: string,
@@ -30,10 +33,7 @@ async function generateInsertSQL(
         if (!hasDefault.bool) {
           // doesn't have default value
           columns.push(item.field);
-          if (
-            item.type.toUpperCase() === "TEXT" ||
-            item.type.toUpperCase() === "BLOB"
-          ) {
+          if (shouldEscapeValue(item)) {
             values.push(
               item.value !== ""
                 ? `'${String(item.value).replace(/'/g, "''")}'`
@@ -48,10 +48,7 @@ async function generateInsertSQL(
       } else {
         // doesn't have default value
         columns.push(item.field);
-        if (
-          item.type.toUpperCase() === "TEXT" ||
-          item.type.toUpperCase() === "BLOB"
-        ) {
+        if (shouldEscapeValue(item)) {
           values.push(
             item.value !== ""
               ? `'${String(item.value).replace(/'/g, "''")}'`
@@ -88,7 +85,7 @@ function generateUpdateSQL(
         item.value === undefined
       ) {
         value = "NULL";
-      } else if (item.type === "TEXT") {
+      } else if (shouldEscapeValue(item)) {
         value = `'${String(item.value).replace(/'/g, "''")}'`; // Escape single quotes
       } else {
         value = item.value.toString(); // Ensure string representation for database

--- a/src/Utils/sqlGenerator.ts
+++ b/src/Utils/sqlGenerator.ts
@@ -10,7 +10,7 @@ interface DataItem {
   default?: string | number | null; // Optional default value
 }
 
-const shouldEscapeValue = (item: DataItem) =>
+const shouldQuoteValue = (item: DataItem) =>
   item.type === "text" || item.type === "blob" || item.type.match(/^varchar/i);
 
 async function generateInsertSQL(
@@ -33,7 +33,7 @@ async function generateInsertSQL(
         if (!hasDefault.bool) {
           // doesn't have default value
           columns.push(item.field);
-          if (shouldEscapeValue(item)) {
+          if (shouldQuoteValue(item)) {
             values.push(
               item.value !== ""
                 ? `'${String(item.value).replace(/'/g, "''")}'`
@@ -48,7 +48,7 @@ async function generateInsertSQL(
       } else {
         // doesn't have default value
         columns.push(item.field);
-        if (shouldEscapeValue(item)) {
+        if (shouldQuoteValue(item)) {
           values.push(
             item.value !== ""
               ? `'${String(item.value).replace(/'/g, "''")}'`
@@ -85,7 +85,7 @@ function generateUpdateSQL(
         item.value === undefined
       ) {
         value = "NULL";
-      } else if (shouldEscapeValue(item)) {
+      } else if (shouldQuoteValue(item)) {
         value = `'${String(item.value).replace(/'/g, "''")}'`; // Escape single quotes
       } else {
         value = item.value.toString(); // Ensure string representation for database

--- a/src/routes/tables.ts
+++ b/src/routes/tables.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express";
 import databaseFunctions from "../Utils/databaseFunctions";
 import * as sqlite3 from "sqlite3"; // Assuming you're using sqlite3
 import sqlGenerator from "../Utils/sqlGenerator";
+import { quoteColumn as q } from "../Utils/helpers";
 
 const router = express.Router();
 
@@ -123,10 +124,7 @@ function tableRoutes(db: sqlite3.Database) {
       const { sqlQuery } = req.body;
       const lowersqlQuery = sqlQuery.toLowerCase();
       if (lowersqlQuery.startsWith("select")) {
-        const response = await databaseFunctions.runSelectQuery(
-          db,
-          sqlQuery
-        );
+        const response = await databaseFunctions.runSelectQuery(db, sqlQuery);
         if (lowersqlQuery.startsWith("select count(*)")) {
           if (response.data !== undefined) {
             res.status(200).json({
@@ -247,7 +245,7 @@ function tableRoutes(db: sqlite3.Database) {
   router.post("/table/delete", async (req: Request, res: Response) => {
     try {
       const { tablename } = req.body;
-      const sql = `DROP TABLE ${tablename};`;
+      const sql = `DROP TABLE ${q(tablename)};`;
       const response = await databaseFunctions.runQuery(db, sql);
       res.status(200).json(response);
     } catch (error) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+export interface DataItem {
+  field: string;
+  name: string;
+  type: string;
+  value?: string | number | null; // Optional value based on type
+  pk?: string; // Optional primary key constraint
+  fk: string;
+  default?: string | number | null; // Optional default value
+}


### PR DESCRIPTION
## Issues encountered
1. I have a table that has a VARCHAR column. I get a 500 error when I try to insert a row into it or I try to update an existing row.
2. I created a table called `update` using knex query builder; and immediately, the sqlite ui stopped working.

This PR is to address the issues I encountered.

## Work done
1. Add support for updating/inserting into tables with VARCHAR columns.
1. Quote column names and table names to allow using keywords as table and column names. Without this change, we cannot use table names such as `update`
1. Simplified functions for generating queries