### PR TITLE
Fix: presence of multiple foreign key sends multiple responses

### DIFF
--- a/dist/routes/tables.js
+++ b/dist/routes/tables.js
@@ -76,13 +76,10 @@ function tableRoutes(db) {
                                 }
                             });
                         }
-                        res.status(200).json(response);
                     });
                 });
             }
-            else {
-                res.status(200).json(response);
-            }
+            res.status(200).json(response);
         }
         catch (error) {
             res.status(500).json({ message: "Internal server error" });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite-gui-node",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite-gui-node",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "description": "GUI for Node js SQLite databases",
   "main": "dist/index.js",
   "scripts": {

--- a/src/routes/tables.ts
+++ b/src/routes/tables.ts
@@ -69,12 +69,10 @@ function tableRoutes(db: Database) {
                   }
                 });
               }
-              res.status(200).json(response);
             });
         });
-      } else {
-        res.status(200).json(response);
       }
+      res.status(200).json(response);
     } catch (error) {
       res.status(500).json({ message: "Internal server error" });
     }


### PR DESCRIPTION
If a table has multiple fk columns, a request to `/infos/:name` results in multiple http responses being sent. This crashes the app. 

This pr is intended to fix this by sending only one response