### PR TITLE
Fix row height issue. 

### DIFF
--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -127,6 +127,10 @@
   text-align: left;
 }
 
+.table tr {
+  height: 45px;
+}
+
 .main_body_header {
   height: 5vh;
   width: 100%;


### PR DESCRIPTION
Updated style.css to fix row height to 45px. This fixes an issue where tables in the table-component and fixed-table divs have slightly different row heights for tables with many rows. This lead to the edit/delete icons in the fixed-table not lining up with the respective content in the table-component. 